### PR TITLE
Fix FileIO integration

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 RData.jl is licensed under the MIT License:
 
-> Copyright (c) 2013-2016: Douglas Bates, John Myles White, Alexey Stukalov,
+> Copyright (c) 2013-2018: Douglas Bates, John Myles White, Alexey Stukalov,
 > and other contributors.
 >
 > Permission is hereby granted, free of charge, to any person obtaining

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,11 @@ Updated to Julia v0.7 (older versions not supported)
 
 ##### Changes
 * update to Julia v0.7+ and drop support for older versions [#42], [#44]
+* improve FileIO integration [#46]
 
 [#42]: https://github.com/JuliaStats/RData.jl/issues/42
 [#44]: https://github.com/JuliaStats/RData.jl/issues/44
+[#46]: https://github.com/JuliaStats/RData.jl/issues/46
 
 ## RData v0.4.0 Release Notes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # RData.jl
 
 [![Julia 0.6 Status](http://pkg.julialang.org/badges/RData_0.6.svg)](http://pkg.julialang.org/?pkg=RData&ver=0.6)
+[![Julia 0.7 Status](http://pkg.julialang.org/badges/RData_0.7.svg)](http://pkg.julialang.org/?pkg=RData&ver=0.7)
+[![Julia 1.0 Status](http://pkg.julialang.org/badges/RData_1.0.svg)](http://pkg.julialang.org/?pkg=RData&ver=1.0)
 
 [![Coverage Status](https://coveralls.io/repos/github/JuliaData/RData.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaData/RData.jl?branch=master)
 [![Build Status](https://travis-ci.org/JuliaData/RData.jl.svg?branch=master)](https://travis-ci.org/JuliaData/RData.jl)

--- a/src/context.jl
+++ b/src/context.jl
@@ -20,7 +20,7 @@ end
 
 int2ver(v::Integer) = VersionNumber(v >> 16, (v >> 8) & 0xff, v & 0xff)
 
-function RDAContext(io::RDAIO, kwoptions::Vector=Any[])
+function RDAContext(io::RDAIO; kwoptions...)
     fmtver = readuint32(io)
     rver = int2ver(readint32(io))
     rminver = int2ver(readint32(io))

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -193,7 +193,9 @@ const BYTECODELANG_Types = Set([BCREPREF, BCREPDEF, LANGSXP, LISTSXP, ATTRLANGSX
 
 function readbytecodelang(bctx::BytecodeContext, bctype::Int32)
     if bctype == BCREPREF # refer to an already defined bytecode
-        return bctx.ref_tab[readint32(bctx.ctx.io)+1]
+        res = bctx.ref_tab[readint32(bctx.ctx.io)+1]
+        @assert !ismissing(res)
+        return res
     elseif bctype ∈ BYTECODELANG_Types
         pos = 0
         hasattr = false


### PR DESCRIPTION
_To be applied after #44_

Improve FileIO integration:
- stop importing FileIO.load(), reexport FileIO.load() (so `Using RData; load(...)` still works)
- rename RData's `load()` into `fileio_load()`
- all `load()` kwargs are passed as kwargs as far as it's possible
- reduce code duplication (merge `fileio_load(::File{})`)