### PR TITLE
Enhance internal class/inherits API

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -54,10 +54,9 @@ end
 
 # convert R vector into Vector of appropriate type
 function jlvec(rv::RVEC, force_missing::Bool=true)
-    cls = class(rv)
-    if cls == R_Date_Class
+    if inherits(rv, R_Date_Class)
         return jlvec(Dates.Date, rv, force_missing)
-    elseif cls == R_POSIXct_Class
+    elseif inherits(rv, R_POSIXct_Class)
         return jlvec(ZonedDateTime, rv, force_missing)
     else
         return jlvec(eltype(rv.data), rv, force_missing)

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -1,4 +1,4 @@
-SXType = UInt8 # stores the type of SEXPREC
+const SXType = UInt8 # stores the type of SEXPREC
 
 ##############################################################################
 ##

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -238,9 +238,16 @@ getattr(ro::ROBJ, attrnm, default) = hasattr(ro, attrnm) ? getindex(ro.attr, att
 
 Base.names(ro::ROBJ) = getattr(ro, "names")
 
-class(ro::ROBJ) = getattr(ro, "class", emptystrvec)
-class(x) = emptystrvec
-inherits(x, clnm) = any(class(x) .== clnm)
+# class of an R object
+class(x::RSEXPREC) = emptystrvec # not an object
+class(ro::ROBJ) = getattr(ro, "class", emptystrvec)::Vector{RString}
+
+# check if R object inherits from a given class
+inherits(x::RSEXPREC, classname) = false
+inherits(ro::ROBJ, classname::AbstractString) = any(isequal(classname), class(ro))
+# check if R object inherits from all given classes
+inherits(ro::ROBJ, classnames::AbstractVector{<:AbstractString}) =
+    all(classname -> any(isequal(classname), class(ro)), classnames)
 
 isdataframe(rl::RList) = inherits(rl, "data.frame")
 isfactor(ri::RIntegerVector) = inherits(ri, "factor")

--- a/test/RDA.jl
+++ b/test/RDA.jl
@@ -18,8 +18,8 @@ module TestRDA
     testdir = dirname(@__FILE__)
     @testset "Reading minimal RData" begin
         df = DataFrame(num = [1.1, 2.2])
-        @test sexp2julia(load("$testdir/data/minimal.rda",convert=false)["df"]) == df
-        @test load("$testdir/data/minimal.rda",convert=true)["df"] == df
+        @test sexp2julia(load("$testdir/data/minimal.rda", convert=false)["df"]) == df
+        @test load("$testdir/data/minimal.rda", convert=true)["df"] == df
         @test load("$testdir/data/minimal_ascii.rda")["df"] == df
     end
 
@@ -30,10 +30,10 @@ module TestRDA
                        chr = ["ab", "c"],
                        factor = categorical(["ab", "c"], true),
                        cplx = [1.1+0.5im, 1.0im])
-        rdf = sexp2julia(load("$testdir/data/types.rda",convert=false)["df"])
+        rdf = sexp2julia(load("$testdir/data/types.rda", convert=false)["df"])
         @test eltypes(rdf) == eltypes(df)
         @test rdf == df
-        rdf_ascii = sexp2julia(load("$testdir/data/types_ascii.rda",convert=false)["df"])
+        rdf_ascii = sexp2julia(load("$testdir/data/types_ascii.rda", convert=false)["df"])
         @test eltypes(rdf_ascii) == eltypes(df)
         @test rdf_ascii == df
     end
@@ -50,26 +50,26 @@ module TestRDA
         append!(df, df[2, :])
         df[3, :num] = NaN
         df[:, :cplx] = [missing, ComplexF64(1,NaN), NaN]
-        @test isequal(sexp2julia(load("$testdir/data/NAs.rda",convert=false)["df"]), df)
+        @test isequal(sexp2julia(load("$testdir/data/NAs.rda", convert=false)["df"]), df)
         # ASCII format saves NaN as NA
         df[3, :num] = missing
         df[:, :cplx] = missing
-        @test isequal(sexp2julia(load("$testdir/data/NAs_ascii.rda",convert=false)["df"]), df)
+        @test isequal(sexp2julia(load("$testdir/data/NAs_ascii.rda", convert=false)["df"]), df)
     end
 
     @testset "Column names conversion" begin
-        rda_names = names(sexp2julia(load("$testdir/data/names.rda",convert=false)["df"]))
+        rda_names = names(sexp2julia(load("$testdir/data/names.rda", convert=false)["df"]))
         expected_names = [:_end, :x!, :x1, :_B_C_, :x, :x_1]
         @test rda_names == expected_names
-        rda_names = names(sexp2julia(load("$testdir/data/names_ascii.rda",convert=false)["df"]))
+        rda_names = names(sexp2julia(load("$testdir/data/names_ascii.rda", convert=false)["df"]))
         @test rda_names == [:_end, :x!, :x1, :_B_C_, :x, :x_1]
     end
 
     @testset "Reading RDA with complex types (environments, closures etc)" begin
-        rda_envs = load("$testdir/data/envs.rda",convert=false)
-        rda_pairlists = load("$testdir/data/pairlists.rda",convert=false)
-        rda_closures = load("$testdir/data/closures.rda",convert=false)
-        rda_cmpfuns = load("$testdir/data/cmpfun.rda",convert=false)
+        rda_envs = load("$testdir/data/envs.rda", convert=false)
+        rda_pairlists = load("$testdir/data/pairlists.rda", convert=false)
+        rda_closures = load("$testdir/data/closures.rda", convert=false)
+        rda_cmpfuns = load("$testdir/data/cmpfun.rda", convert=false)
     end
 
     @testset "Proper handling of factor and ordered" begin


### PR DESCRIPTION
A few small enhancements to `class()`/`inherits()`:
  - make these methods applicable only to R SEXPs (non-R objects would generate `MethodError`)
  - make sure `class()` always returns `RString` vector to enhance type inference in the caller code
  - avoid creating temporary boolean array by `inherits()`
  - add `inherits()` for a vector of class names (all class names should be inherited)
  - add `class()`/inherits()` tests