### PR TITLE
DictoVec: cleanup and add tests

### DIFF
--- a/src/DictoVec.jl
+++ b/src/DictoVec.jl
@@ -77,6 +77,23 @@ function Base.get(f::Function, dict::DictoVec, key)
     return get(f, dict, ix)
 end
 
+function Base.delete!(dict::DictoVec, key)
+    ix = pop!(dict.name2index, key, 0)
+    if ix > 0
+        deleteat!(dict.data, ix)
+        deleteat!(dict.index2name, ix)
+        if ix <= length(dict)
+            # update indices
+            for (k, oldix) in pairs(dict.name2index)
+                if oldix > ix
+                    dict.name2index[k] = oldix - 1
+                end
+            end
+        end
+    end
+    return dict
+end
+
 Base.keys(dict::DictoVec) = keys(dict.name2index)
 
 Base.values(dict::DictoVec) = dict.data

--- a/test/DictoVec.jl
+++ b/test/DictoVec.jl
@@ -63,6 +63,16 @@ end
     @test length(dv) == 1
     @test dv[1] == :yy
     @test dv["a"] == :yy
+
+    # deleting an element by key
+    @test delete!(dv, 1) === dv
+    @test length(dv) == 1
+    delete!(dv, "b")
+    @test length(dv) == 1
+    delete!(dv, "a")
+    @test length(dv) == 0
+    @test !haskey(dv, "a")
+    @test_throws BoundsError dv[1]
 end
 
 @testset "Nameless DictoVec" begin
@@ -92,6 +102,10 @@ end
     @test dv["a"] === 3.0
     @test dv[4] === 3.0
     @test show2string(dv) == "DictoVec{Float64}(2.0,5.0,4.0,\"a\"=>3.0)"
+
+    @test delete!(dv, "a") === dv
+    @test length(dv) == 3
+    @test !haskey(dv, "a")
 end
 
 @testset "DictoVec with names" begin
@@ -119,6 +133,13 @@ end
     @test dv["a"] === 6.0
     @test dv[1] === 6.0
     @test show2string(dv) == "DictoVec{Float64}(\"a\"=>6.0,\"b\"=>5.0,\"c\"=>4.0)"
+
+    # deleting an element from the middle
+    @test delete!(dv, "b") === dv
+    @test length(dv) == 2
+    @test !haskey(dv, "b")
+    @test dv[2] == 4.0 # indices has updated
+    @test show2string(dv) == "DictoVec{Float64}(\"a\"=>6.0,\"c\"=>4.0)"
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,5 +4,6 @@ using Test
 include("decompression.jl")
 include("errors.jl")
 include("basic.jl")
+include("DictoVec.jl")
 include("RDA.jl")
 include("RDS.jl")


### PR DESCRIPTION
- use explicit types for name2index, index2name
- use Vector{RString?} for index2name
- relax signatures (use AbstractVector, AbstractString, Integer)
- fix show()
- add DictoVec tests