### PR TITLE
Set version to 0.6.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RData"
 uuid = "df47a6cb-8c03-5eed-afd8-b6050d6c41da"
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"


### PR DESCRIPTION
This version would provide support for Bzip2/Xz-compressed RData files (#62).
This would also be the last version to support Julia 0.7.
The new versions will require Julia 1.0+ and DataFrames >= 0.19 (which requires Julia 1.0+ too).