### PR TITLE
add TagBot, CompatHelper; remove inequalities from Project.toml

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,26 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.2.0]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,12 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 0 0 * * 0
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
+  - 1
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ julia:
   - 1.0
   - 1
   - nightly
+matrix:
+  fast_finish: true
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/Project.toml
+++ b/Project.toml
@@ -12,12 +12,12 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-CategoricalArrays = "≥ 0.3.0"
-CodecZlib = "≥ 0.4.0"
-DataFrames = "≥ 0.19.0"
-FileIO = "≥ 1.0.5"
-TimeZones = "≥ 0.7.3"
-julia = "1.0"
+CategoricalArrays = "0.5, 0.6, 0.7"
+CodecZlib = "0.4, 0.5, 0.6"
+DataFrames = "0.19, 0.20"
+FileIO = "1.0.5"
+TimeZones = "0.7, 0.8, 0.9, 0.10"
+julia = "1"
 
 [extras]
 CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"


### PR DESCRIPTION
`git tag -l` doesn't show v0.7.0.  this will make sure tags are created for new versions going forward.