### PR TITLE
Fix compressor detection with recent FileIO, tweak CI

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,23 +1,12 @@
 name: CompatHelper
-
 on:
   schedule:
-    - cron: '0 0 * * 0'
-  issues:
-    types: [opened, reopened]
-
+    - cron: '00 00 * * *'
+  workflow_dispatch:
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.2.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+  CompatHelper:
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -20,12 +21,20 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+          - windows-latest
         arch:
           - x64
-        include:
-          - os: windows-latest
+          - x86
+        include: # macos doesn't support x86
+          - os: macos-latest
+            version: '1.0'
+            arch: x64
+          - os: macos-latest
             version: '1'
-            arch: x86
+            arch: x64
+          - os: macos-latest
+            version: 'nightly'
+            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RData"
 uuid = "df47a6cb-8c03-5eed-afd8-b6050d6c41da"
-version = "0.7.3"
+version = "0.8.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
@@ -16,7 +16,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 CategoricalArrays = "0.8, 0.9"
 CodecZlib = "0.4, 0.5, 0.6, 0.7"
 DataFrames = "0.21, 0.22"
-FileIO = "1.0.5"
+FileIO = "1.6.5"
 Requires = "1.0.0"
 TimeZones = "0.7, 0.8, 0.9, 0.10, 1.0"
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # RData.jl
 
-[![CI](https://github.com/JuliaData/RData.jl/workflows/CI/badge.svg)](https://github.com/JuliaData/RData.jl/actions?query=workflow%3ACI)
+[![CI](https://github.com/JuliaData/RData.jl/workflows/CI/badge.svg)](https://github.com/JuliaData/RData.jl/actions?query=workflow%3ACI+branch%3Amain)
 [![codecov](https://codecov.io/gh/JuliaData/RData.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaData/RData.jl)
-[![deps](https://juliahub.com/docs/RData/deps.svg)](https://juliahub.com/ui/Packages/RData/yjnue?t=2)
 [![deps](https://juliahub.com/docs/RData/deps.svg)](https://juliahub.com/ui/Packages/RData/idMMA?t=2)
 [![version](https://juliahub.com/docs/RData/version.svg)](https://juliahub.com/ui/Packages/RData/idMMA)
 [![pkgeval](https://juliahub.com/docs/RData/pkgeval.svg)](https://juliahub.com/ui/Packages/RData/idMMA)

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -2,7 +2,7 @@ using CodecZlib, Requires
 
 abstract type ArchiveFormat{S} end
 
-decompressor_stream(::Type{ArchiveFormat{:Gzip}}, io::IOStream) = GzipDecompressorStream(io)
+decompressor_stream(::Type{ArchiveFormat{:GZIP}}, io::IOStream) = GzipDecompressorStream(io)
 
 # Handles the case when we are loading a supported archive format but the codec is not loaded
 function decompressor_stream(::Type{ArchiveFormat{S}}, io::IOStream) where S
@@ -12,34 +12,19 @@ end
 # called by __init__() to enable support for optional codecs
 function define_optional_decompressor_streams()
     @require CodecBzip2="523fee87-0ab8-5b00-afb7-3ecf72e48cfd" begin
-        decompressor_stream(::Type{ArchiveFormat{:Bzip2}}, io::IOStream) = CodecBzip2.Bzip2DecompressorStream(io)
+        decompressor_stream(::Type{ArchiveFormat{:BZIP2}}, io::IOStream) = CodecBzip2.Bzip2DecompressorStream(io)
     end
     @require CodecXz="ba30903b-d9e8-5048-a5ec-d1f5b0d4b47b" begin
-        decompressor_stream(::Type{ArchiveFormat{:Xz}}, io::IOStream) = CodecXz.XzDecompressorStream(io)
+        decompressor_stream(::Type{ArchiveFormat{:XZ}}, io::IOStream) = CodecXz.XzDecompressorStream(io)
     end
 end
 
-# Magic numbers that identify the supported compression formats
-const MAGIC_GZIP = b"\x1F\x8B"
-const MAGIC_BZIP2 = b"BZh"
-const MAGIC_XZ = b"\xFD7zXZ\x00"
-
+# decompress the stream if it's compressed (by a supported codec)
 function decompress(io)
-    # Read the first 6 bytes to obtain the magic number if there is one.
-    buffer = zeros(UInt8, 6)
-    readbytes!(io, buffer)
-    seekstart(io)
-
-    # Check for any of the gzip, bzip2 or xz magic numbers
-    if buffer[1:2] == MAGIC_GZIP
-        return decompressor_stream(ArchiveFormat{:Gzip}, io)
-    elseif buffer[1:3] == MAGIC_BZIP2
-        return decompressor_stream(ArchiveFormat{:Bzip2}, io)
-    elseif buffer == MAGIC_XZ
-        return decompressor_stream(ArchiveFormat{:Xz}, io)
+    format = FileIO.detect_compressor(io, formats=["GZIP", "BZIP2", "XZ"])
+    if format !== nothing
+        return decompressor_stream(ArchiveFormat{Symbol(format)}, io)
+    else
+        return io # not compressed
     end
-
-    # If none of the magic numbers match, we assume the file is not compressed
-
-    return io
 end

--- a/test/decompression.jl
+++ b/test/decompression.jl
@@ -4,13 +4,27 @@ using DataFrames, RData, Test
 rdata_path = joinpath(dirname(@__FILE__), "data_v3")
 df = DataFrame(num = [1.1, 2.2])
 
+function test_missing_compressor(filename::AbstractString, codec::Symbol)
+    @test_throws CapturedException load(joinpath(rdata_path, filename))
+    caught = nothing
+    try
+        load(joinpath(rdata_path, filename))
+    catch ex
+        caught = ex
+    end
+
+    @test caught isa CapturedException
+    @test caught.ex isa CodecMissingError
+    @test caught.ex.formatName == codec
+end
+
 @testset "Loading compressed RData files" begin
     @testset "When the optional compression codecs are not loaded" begin
-        @test_warn "Error encountered while loading" begin
-            @test_throws CodecMissingError load(joinpath(rdata_path, "compressed_bzip2.rda"))
+        @test_warn "Error encountered while load" begin
+            test_missing_compressor("compressed_bzip2.rda", :BZIP2)
         end
-        @test_warn "Error encountered while loading" begin
-            @test_throws CodecMissingError load(joinpath(rdata_path, "compressed_xz.rda"))
+        @test_warn "Error encountered while load" begin
+            test_missing_compressor("compressed_xz.rda", :XZ)
         end
     end
 


### PR DESCRIPTION
- Bump FileIO requirement to 1.6.5 to fix #84 and replace `RData` compressor detection code with `FileIO.detect_compressor()`.
- Expand the CI matrix (test everywhere except x86 MacOS), cleanup the badges.
- Try to reenable *CompatHelper*.