### PR TITLE
DictoVec: derive from AbstractVector

### DIFF
--- a/src/DictoVec.jl
+++ b/src/DictoVec.jl
@@ -3,7 +3,7 @@ Container that mimics R vector behaviour.
 Elements could be accessed either by indices as a normal vector,
 or (optionally) by string keys as a dictionary.
 """
-struct DictoVec{T}
+struct DictoVec{T} <: AbstractVector{T}
     data::Vector{T}
     name2index::Dict{RString, Int}
     index2name::Vector{Union{RString, Nothing}}
@@ -39,6 +39,7 @@ Base.eltype(::Type{DictoVec{T}}) where T = T
 Base.eltype(dict::DictoVec) = eltype(typeof(dict))
 Base.length(dict::DictoVec) = length(dict.data)
 Base.isempty(dict::DictoVec) = isempty(dict.data)
+Base.size(dict::DictoVec) = size(dict.data)
 
 # key-based indexing
 Base.haskey(dict::DictoVec, key) = haskey(dict.name2index, key)

--- a/test/DictoVec.jl
+++ b/test/DictoVec.jl
@@ -17,7 +17,9 @@ end
 
     @test typeof(dv) === DictoVec{Symbol}
     @test eltype(dv) === Symbol
+    @test dv isa AbstractVector{Symbol}
     @test length(dv) == 0
+    @test size(dv) == (0,)
     @test isempty(dv)
     @test collect(keys(dv)) == RData.RString[]
     @test values(dv) == Symbol[]
@@ -85,8 +87,10 @@ end
 @testset "Nameless DictoVec" begin
     dv = DictoVec([2.0, 5.0, 4.0])
     @test typeof(dv) === DictoVec{Float64}
+    @test dv isa AbstractVector{Float64}
     @test eltype(dv) === Float64
     @test length(dv) == 3
+    @test size(dv) == (3,)
     @test !isempty(dv)
     @test !haskey(dv, 1)
     @test !haskey(dv, "a")
@@ -129,8 +133,10 @@ end
 @testset "DictoVec with names" begin
     dv = DictoVec([2.0, 5.0, 4.0], ["a", "b", "c"])
     @test typeof(dv) === DictoVec{Float64}
+    @test dv isa AbstractVector{Float64}
     @test eltype(dv) === Float64
     @test length(dv) == 3
+    @test size(dv) == (3,)
     @test !isempty(dv)
     @test !haskey(dv, 1)
     @test haskey(dv, "a")


### PR DESCRIPTION
Sometimes R data.frame are constructed such that columns have element names.
*RData.jl* would then convert these columns into *DictoVec* object.
However, when converting R data.frame into *DataFrames.jl* *DataFrame* object, all column containers are required to support *AbstractVector* interface.
This PR fixes the failure of *DataFrame* construction by making *DictoVec* inherited from *AbstractVector* and adding necessary methods that are used during *DataFrame* construction.