### PR TITLE
Fix tests for Julia 1.11

### DIFF
--- a/test/DictoVec.jl
+++ b/test/DictoVec.jl
@@ -48,7 +48,7 @@ end
     @test show2string(dv) == "DictoVec{Symbol}()"
 
     # add an element
-    @test_throws Exception (dv[1] = "xx") # incompatible value
+    @test_throws MethodError (dv["A"] = "xx") # incompatible value
     @test length(dv) == 0
     @test_throws BoundsError (dv[1] = :xx) # cannot create new elements by integer index
     @test length(dv) == 0

--- a/test/DictoVec.jl
+++ b/test/DictoVec.jl
@@ -48,7 +48,7 @@ end
     @test show2string(dv) == "DictoVec{Symbol}()"
 
     # add an element
-    @test_throws MethodError (dv[1] = "xx") # incompatible value
+    @test_throws Exception (dv[1] = "xx") # incompatible value
     @test length(dv) == 0
     @test_throws BoundsError (dv[1] = :xx) # cannot create new elements by integer index
     @test length(dv) == 0


### PR DESCRIPTION
An exception changed from a `MethodError` to a `BoundsError` in Julia 1.11.